### PR TITLE
documentar puerto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:3.1
+FROM mcr.microsoft.com/dotnet/runtime:3.1
+EXPOSE 80
 COPY ./bin/Debug/netcoreapp3.1/linux-x64/publish/ ./
 ENTRYPOINT ["dotnet", "helloworld.dll"]


### PR DESCRIPTION
se documenta el puerto por el cual funciona la aplicación, para que los devops sepan a que puerto hacer la conexion